### PR TITLE
meta dependencies should use the full role name

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -12,4 +12,4 @@ galaxy_info:
   categories:
     - system
 dependencies:
-  - config_encoder_filters
+  - jtyr.config_encoder_filters


### PR DESCRIPTION
When installing roles through Galaxy, "config_encoder_filters" is inextent, while "jtyr.config_encoder_filters" is OK.