### PR TITLE
Works with Debian Jessie

### DIFF
--- a/defaults/main.yaml
+++ b/defaults/main.yaml
@@ -13,8 +13,12 @@ bacula_client_config_file_path: /etc/bacula/bacula-fd.conf
 # Values of the default FileDaemon options
 bacula_client_config_filedaemon_options_name: "{{ inventory_hostname }}-fd"
 bacula_client_config_filedaemon_options_fdport: 9102
-bacula_client_config_filedaemon_options_working_directory: /var/spool/bacula
-bacula_client_config_filedaemon_options_pid_directory: /var/run
+bacula_client_config_filedaemon_options_working_directory: "{{
+    '/var/spool/bacula' if ansible_os_family == "RedHat"
+    else '/var/lib/bacula' }}"
+bacula_client_config_filedaemon_options_pid_directory: "{{
+    '/var/run' if ansible_os_family == "RedHat"
+    else '/var/run/bacula' }}"
 bacula_client_config_filedaemon_options_pid_max_jobs: 20
 
 # Default FileDaemon resource options for the first FileDaemon definition

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -9,6 +9,9 @@ galaxy_info:
     - name: EL
       versions:
         - 6
+    - name: Debian
+      versions:
+        - jessie
   categories:
     - system
 dependencies:

--- a/tasks/main.yaml
+++ b/tasks/main.yaml
@@ -1,12 +1,5 @@
 ---
 
-- name: Test distribution
-  assert:
-    that: >
-      ansible_os_family == "RedHat"
-  tags:
-    - bacula_client_assert
-
 - name: Install Bacula Client package
   package:
     name: "{{ bacula_client_pkg }}"

--- a/tasks/main.yaml
+++ b/tasks/main.yaml
@@ -1,5 +1,13 @@
 ---
 
+- name: Test distribution
+  assert:
+    that: >
+      ansible_os_family == "RedHat" or
+      ansible_os_family == "Debian"
+  tags:
+    - bacula_client_assert
+
 - name: Install Bacula Client package
   package:
     name: "{{ bacula_client_pkg }}"


### PR DESCRIPTION
This role will work with Debian (tested with Jessie) if you remove the task `Test distribution`, and set these variables to those values:
- `bacula_client_config_filedaemon_options_working_directory: /var/lib/bacula`
- `bacula_client_config_filedaemon_options_pid_directory: /var/run/bacula`

As a side note, maybe that instead of installing package `bacula-client` you should default to the simpler `bacula-fd`?